### PR TITLE
[FIX] Accept netherite as material for beacons

### DIFF
--- a/src/main/java/de/julianweinelt/ubm/blocks/BlockNetheriteBlock.java
+++ b/src/main/java/de/julianweinelt/ubm/blocks/BlockNetheriteBlock.java
@@ -1,0 +1,26 @@
+package de.julianweinelt.ubm.blocks;
+
+import de.julianweinelt.ubm.misc.ModCreativeTabs;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+import javax.annotation.Nonnull;
+
+public class BlockNetheriteBlock extends Block {
+    public BlockNetheriteBlock() {
+        super(Material.ROCK);
+        this.setCreativeTab(ModCreativeTabs.UBM_TAB_NETHER);
+        this.setRegistryName("netherite_block");
+        this.setUnlocalizedName("netherite_block");
+        this.setResistance(1200);
+        this.setHardness(50F);
+        this.setHarvestLevel("pickaxe", 4);
+    }
+
+    @Override
+    public boolean isBeaconBase(@Nonnull IBlockAccess worldObj, @Nonnull BlockPos pos, @Nonnull BlockPos beacon) {
+        return true;
+    }
+}

--- a/src/main/java/de/julianweinelt/ubm/blocks/ModBlocks.java
+++ b/src/main/java/de/julianweinelt/ubm/blocks/ModBlocks.java
@@ -330,10 +330,7 @@ public class ModBlocks {
         register(BUDDING_AMETHYST, event);
 
 
-        NETHERITE_BLOCK = new Block(Material.ROCK)
-                .setUnlocalizedName("netherite_block")
-                .setRegistryName("netherite_block")
-                .setCreativeTab(ModCreativeTabs.UBM_TAB_NETHER);
+        NETHERITE_BLOCK = new BlockNetheriteBlock();
         register(NETHERITE_BLOCK, event);
 
         TARGET = new Block(Material.PLANTS)

--- a/src/main/java/de/julianweinelt/ubm/items/ItemNetheriteIngot.java
+++ b/src/main/java/de/julianweinelt/ubm/items/ItemNetheriteIngot.java
@@ -1,0 +1,18 @@
+package de.julianweinelt.ubm.items;
+
+import de.julianweinelt.ubm.misc.ModCreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class ItemNetheriteIngot extends Item {
+    public ItemNetheriteIngot() {
+        setUnlocalizedName("netherite_ingot");
+        setRegistryName("netherite_ingot");
+        setCreativeTab(ModCreativeTabs.UBM_TAB_NETHER);
+    }
+
+    @Override
+    public boolean isBeaconPayment(ItemStack stack) {
+        return true;
+    }
+}

--- a/src/main/java/de/julianweinelt/ubm/items/ItemNetheriteIngot.java
+++ b/src/main/java/de/julianweinelt/ubm/items/ItemNetheriteIngot.java
@@ -4,6 +4,8 @@ import de.julianweinelt.ubm.misc.ModCreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public class ItemNetheriteIngot extends Item {
     public ItemNetheriteIngot() {
         setUnlocalizedName("netherite_ingot");
@@ -12,7 +14,7 @@ public class ItemNetheriteIngot extends Item {
     }
 
     @Override
-    public boolean isBeaconPayment(ItemStack stack) {
+    public boolean isBeaconPayment(@Nonnull ItemStack stack) {
         return true;
     }
 }

--- a/src/main/java/de/julianweinelt/ubm/items/ModItems.java
+++ b/src/main/java/de/julianweinelt/ubm/items/ModItems.java
@@ -230,10 +230,7 @@ public class ModItems {
                 .setRegistryName("copper_torch")
                 .setCreativeTab(ModCreativeTabs.UBM_TAB_COPPER_AGE);
         event.getRegistry().register(COPPER_INGOT);
-        NETHERITE_INGOT = new Item()
-                .setUnlocalizedName("netherite_ingot")
-                .setRegistryName("netherite_ingot")
-                .setCreativeTab(ModCreativeTabs.UBM_TAB_NETHER);
+        NETHERITE_INGOT = new ItemNetheriteIngot();
         event.getRegistry().register(NETHERITE_INGOT);
         WOLF_ARMOR = new Item()
                 .setUnlocalizedName("wolf_armor")


### PR DESCRIPTION
Beacons now accept `netherite ingot`s as payment and `block of netherite` as base block.