### PR TITLE
Modify Gradle build step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,10 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
         with:
           gradle-version: '4.9'
-    
-      - name: Build with Gradle 4.9
-        run: gradle build
+      - name: Build with Gradle
+        run: ./gradlew build --refresh-dependencies
+      #- name: Build with Gradle 4.9
+        #run: gradle build
         
       - uses: Kir-Antipov/mc-publish@v3.3
         with:


### PR DESCRIPTION
Updated Gradle build step to use './gradlew' and refresh dependencies.